### PR TITLE
Set up Cloud dev environment + AGENTS.md notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,3 +82,22 @@ Use `.agents/skills/repo-update-docs/SKILL.md` to refresh `README.md` and public
 - Supported PHP versions: `docs-internal/supported-versions.md`
 - Public user docs: `docs/`
 - Open follow-ups: #187 (Set For Life tests), #188 (constitution hotpicks note), #189 (GameController refactor), #190 (HTTP feature test)
+
+## Cursor Cloud specific instructions
+
+The Cloud VM runs PHP 8.3, Composer, and Node directly (no Docker/Sail). Use the plain
+tooling instead of the `./vendor/bin/sail` wrappers documented above:
+
+- Serve: `php artisan serve --host=0.0.0.0 --port=8000`
+- Test: `php artisan test` (or `vendor/bin/phpunit`) — uses in-memory SQLite, no DB service needed
+- Lint: `./vendor/bin/pint --test` (fix with `./vendor/bin/pint`)
+
+Non-obvious caveats:
+
+- Frontend asset build (`npm run dev`/`npm run prod`) currently fails: `laravel-mix@6` requires
+  `webpack/lib/SizeFormatHelpers`, removed in the pinned `webpack@5.108`. The app still runs because
+  compiled assets are committed under `public/css` and `public/js`, and CI does not build assets. Do
+  not rebuild assets unless you first resolve that dependency incompatibility.
+- The `/game/{slug}/generate` routes fetch live draw-history CSVs from the National Lottery API on
+  first use (outbound HTTPS required), caching them to `storage/app/lottery/` for 24h. After the cache
+  is warm the pages render offline.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the National Lottery Generator on the Cursor Cloud VM and verifies it end-to-end. The only repository change is documentation: a new `## Cursor Cloud specific instructions` section in `AGENTS.md`.

## Environment setup

- Installed PHP 8.3 (+ mbstring, xml, curl, zip, bcmath, sqlite3, gd, intl) and Composer; Node 22 was already present.
- `composer install`, `npm install`, `.env` created, `php artisan key:generate`.
- Update script (dependency refresh on startup): `composer install` + `npm install`.

## Verification

| Task | Command | Result |
|------|---------|--------|
| Lint | `./vendor/bin/pint --test` | passed |
| Tests | `php artisan test` | 61 passed (483 assertions) |
| Run | `php artisan serve` | homepage HTTP 200 |
| Hello world | `/game/lotto/generate`, `/game/euromillions/generate` | generated suggested lines from live draw data |

## Notes

- Frontend asset build (`npm run dev`) fails due to a pre-existing `laravel-mix@6` vs `webpack@5.108` incompatibility (`webpack/lib/SizeFormatHelpers` removed). Compiled assets are committed under `public/`, and CI does not build assets, so the app runs regardless. Documented in AGENTS.md.
- `/game/{slug}/generate` fetches live CSVs from the National Lottery API (outbound HTTPS) and caches them for 24h.

<a href="https://cursor.com/agents/bc-63e78315-052c-4687-bb6c-d7dc09f0367a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feuromillions_generation_demo.mp4"><img src="https://cursor.com/artifacts/c/art-b7b7dc38-71ef-4e15-a216-3697e10b859b" alt="euromillions_generation_demo.mp4" /></a>
![Lotto generated numbers](https://cursor.com/artifacts/c/art-809f82e0-bdf1-4e68-b358-b8a8224526f8)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63e78315-052c-4687-bb6c-d7dc09f0367a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63e78315-052c-4687-bb6c-d7dc09f0367a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

