### PR TITLE
Add Set For Life unit tests (closes #187)

### DIFF
--- a/specs/set-for-life/spec.md
+++ b/specs/set-for-life/spec.md
@@ -12,7 +12,7 @@
 
 A user generates suggested Set For Life lines with 5 main numbers and 1 life ball based on historical draw data.
 
-**Independent Test**: Call `SetForLifeGenerate::generate()` — no dedicated unit test exists.
+**Independent Test**: Call `SetForLifeGenerate::generate()` via `SetForLifeGenerateTest`.
 
 **Acceptance Scenarios**:
 
@@ -28,8 +28,4 @@ A user generates suggested Set For Life lines with 5 main numbers and 1 life bal
 ## Success Criteria
 
 - **SC-001**: Generate page renders correctly at `/game/set-for-life/generate`
-
-## Gaps Identified
-
-- ⚠️ No `SetForLifeGenerateTest.php` or `SetForLifeDownloadTest.php`
-- ⚠️ Constitution requires unit tests for lottery logic — this game is untested
+- **SC-002**: Unit tests cover download and generate services

--- a/specs/set-for-life/tasks.md
+++ b/specs/set-for-life/tasks.md
@@ -1,13 +1,11 @@
 # Tasks: Set For Life
 
-**Status**: Migrated — implementation complete, tests missing
+**Status**: Migrated — implementation complete
 
 - [x] T001 Add `set-for-life` entry to `config/games.php`
 - [x] T002 Create `SetForLifeDownload` in `app/Services/Lottery/SetForLifeDownload.php`
 - [x] T003 Create `SetForLifeGenerate` in `app/Services/Lottery/SetForLifeGenerate.php`
 - [x] T004 Wire dispatch in `GameController::generateSetForLife()`
 
-## Gaps (Not Completed)
-
-- [ ] T005 [P] Unit test `tests/Unit/Lottery/SetForLifeDownloadTest.php`
-- [ ] T006 [P] Unit test `tests/Unit/Lottery/SetForLifeGenerateTest.php`
+- [x] T005 [P] Unit test `tests/Unit/Lottery/SetForLifeDownloadTest.php`
+- [x] T006 [P] Unit test `tests/Unit/Lottery/SetForLifeGenerateTest.php`

--- a/tests/Unit/Lottery/DownloaderTestCase.php
+++ b/tests/Unit/Lottery/DownloaderTestCase.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Lottery;
 
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 abstract class DownloaderTestCase extends TestCase
 {

--- a/tests/Unit/Lottery/SetForLifeDownloadTest.php
+++ b/tests/Unit/Lottery/SetForLifeDownloadTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Unit tests for SetForLifeDownload class.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Lottery;
+
+use App\Services\Lottery\SetForLifeDownload;
+
+/**
+ * Unit tests for SetForLifeDownload class.
+ *
+ * @package Tests\Unit\Lottery
+ */
+class SetForLifeDownloadTest extends DownloaderTestCase
+{
+    /**
+     * @inheritdoc
+     */
+    protected function download($failDownload = false, $failRename = false): string
+    {
+        return SetForLifeDownload::download($failDownload, $failRename);
+    }
+}

--- a/tests/Unit/Lottery/SetForLifeGenerateTest.php
+++ b/tests/Unit/Lottery/SetForLifeGenerateTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * Unit tests for SetForLifeGenerate class.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Lottery;
+
+use App\Services\Lottery\SetForLifeGenerate;
+
+/**
+ * Unit tests for SetForLifeGenerate class.
+ *
+ * @package Tests\Unit\Lottery
+ */
+class SetForLifeGenerateTest extends GenerateTestCase
+{
+    /**
+     * @inheritdoc
+     */
+    protected function generate(): array
+    {
+        return SetForLifeGenerate::generate();
+    }
+
+    /**
+     * Test findMostPopularLifeBall returns most frequent Life Ball.
+     */
+    public function testFindMostPopularLifeBallReturnsCorrectValue()
+    {
+        $lines1 = [
+            ['mainNumbers' => [1, 2, 3, 4, 5], 'lifeBall' => [1]],
+            ['mainNumbers' => [6, 7, 8, 9, 10], 'lifeBall' => [2]],
+        ];
+        $lines2 = [
+            ['mainNumbers' => [11, 12, 13, 14, 15], 'lifeBall' => [1]],
+            ['mainNumbers' => [16, 17, 18, 19, 20], 'lifeBall' => [1]],
+            ['mainNumbers' => [21, 22, 23, 24, 25], 'lifeBall' => [3]],
+        ];
+
+        $reflection = new \ReflectionClass(SetForLifeGenerate::class);
+        $method = $reflection->getMethod('findMostPopularLifeBall');
+
+        $result = $method->invokeArgs(null, [$lines1, $lines2]);
+        $this->assertEquals(1, $result, 'Should return Life Ball 1 as it appears 3 times');
+    }
+
+    /**
+     * Test findMostPopularLifeBall returns default when no valid data.
+     */
+    public function testFindMostPopularLifeBallReturnsDefaultWhenEmpty()
+    {
+        $lines1 = [];
+        $lines2 = [];
+
+        $reflection = new \ReflectionClass(SetForLifeGenerate::class);
+        $method = $reflection->getMethod('findMostPopularLifeBall');
+
+        $result = $method->invokeArgs(null, [$lines1, $lines2]);
+        $this->assertEquals(1, $result, 'Should return default value 1 when no data');
+    }
+
+    /**
+     * Test findMostPopularLifeBall handles lines without life ball.
+     */
+    public function testFindMostPopularLifeBallHandlesInvalidLines()
+    {
+        $lines1 = [
+            ['mainNumbers' => [1, 2, 3, 4, 5]],  // No life ball
+            ['mainNumbers' => [6, 7, 8, 9, 10], 'lifeBall' => [5]],
+        ];
+        $lines2 = [
+            ['mainNumbers' => [11, 12, 13, 14, 15], 'lifeBall' => []],  // Empty life ball
+        ];
+
+        $reflection = new \ReflectionClass(SetForLifeGenerate::class);
+        $method = $reflection->getMethod('findMostPopularLifeBall');
+
+        $result = $method->invokeArgs(null, [$lines1, $lines2]);
+        $this->assertEquals(5, $result, 'Should return Life Ball 5 as it\'s the only valid one');
+    }
+
+    /**
+     * Test findFirstLineIndexWithLifeBall finds correct index.
+     */
+    public function testFindFirstLineIndexWithLifeBallReturnsCorrectIndex()
+    {
+        $lines = [
+            ['mainNumbers' => [1, 2, 3, 4, 5], 'lifeBall' => [2]],
+            ['mainNumbers' => [6, 7, 8, 9, 10], 'lifeBall' => [5]],
+            ['mainNumbers' => [11, 12, 13, 14, 15], 'lifeBall' => [5]],
+            ['mainNumbers' => [16, 17, 18, 19, 20], 'lifeBall' => [3]],
+        ];
+
+        $reflection = new \ReflectionClass(SetForLifeGenerate::class);
+        $method = $reflection->getMethod('findFirstLineIndexWithLifeBall');
+
+        $result = $method->invokeArgs(null, [$lines, 5]);
+        $this->assertEquals(1, $result, 'Should return index 1 for first line with Life Ball 5');
+    }
+
+    /**
+     * Test findFirstLineIndexWithLifeBall returns null when not found.
+     */
+    public function testFindFirstLineIndexWithLifeBallReturnsNullWhenNotFound()
+    {
+        $lines = [
+            ['mainNumbers' => [1, 2, 3, 4, 5], 'lifeBall' => [2]],
+            ['mainNumbers' => [6, 7, 8, 9, 10], 'lifeBall' => [3]],
+        ];
+
+        $reflection = new \ReflectionClass(SetForLifeGenerate::class);
+        $method = $reflection->getMethod('findFirstLineIndexWithLifeBall');
+
+        $result = $method->invokeArgs(null, [$lines, 10]);
+        $this->assertNull($result, 'Should return null when Life Ball 10 not found');
+    }
+
+    /**
+     * Test findFirstLineIndexWithLifeBall returns index 0 when first line matches.
+     */
+    public function testFindFirstLineIndexWithLifeBallReturnsZeroForFirstLine()
+    {
+        $lines = [
+            ['mainNumbers' => [1, 2, 3, 4, 5], 'lifeBall' => [7]],
+            ['mainNumbers' => [6, 7, 8, 9, 10], 'lifeBall' => [3]],
+        ];
+
+        $reflection = new \ReflectionClass(SetForLifeGenerate::class);
+        $method = $reflection->getMethod('findFirstLineIndexWithLifeBall');
+
+        $result = $method->invokeArgs(null, [$lines, 7]);
+        $this->assertEquals(0, $result, 'Should return 0 when first line matches (not null)');
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #187 by adding the missing Set For Life unit tests identified in `specs/set-for-life/tasks.md` (T005/T006).

- **`SetForLifeDownloadTest`** — extends `DownloaderTestCase` with the standard download/rename failure coverage
- **`SetForLifeGenerateTest`** — extends `GenerateTestCase` for output contract checks, plus reflection-based tests for `findMostPopularLifeBall` and `findFirstLineIndexWithLifeBall` (mirroring `ThunderballGenerateTest`)

## Additional fix

`DownloaderTestCase` now extends Laravel's `Tests\TestCase` instead of `PHPUnit\Framework\TestCase`. Download services use Laravel's HTTP client, so without the application container the `testDownloadOK` cases failed under `vendor/bin/phpunit` (as run in CI). This fix applies to all game download tests, not just Set For Life.

## Verification

```bash
cp .env.example .env && php artisan key:generate
vendor/bin/phpunit --filter=SetForLife   # 14 passed
vendor/bin/phpunit                       # 75 passed
./vendor/bin/pint --test                 # passed
```

## Spec updates

- `specs/set-for-life/tasks.md` — T005/T006 marked complete
- `specs/set-for-life/spec.md` — gaps removed; success criteria updated
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd1f9866-d08c-4463-9a4e-9ef71c37a4fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd1f9866-d08c-4463-9a4e-9ef71c37a4fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

