### PR TITLE
Fix Cloud Agent environment build (composer-only install)

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,10 @@
+{
+  "name": "National Lottery Generator",
+  "install": "composer install --no-interaction --no-progress",
+  "ports": [
+    {
+      "name": "PHP dev server",
+      "port": 8000
+    }
+  ]
+}

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,5 +1,9 @@
 {
   "name": "National Lottery Generator",
+  "build": {
+    "dockerfile": "../.devcontainer/Dockerfile",
+    "context": ".."
+  },
   "install": "composer install --no-interaction --no-progress",
   "ports": [
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Environment build [bld-20260813-7d49810a-80e8-4cdb-b781-f1ce0d72b103](https://cursor.com/dashboard/cloud-agents/builds/bld-20260813-7d49810a-80e8-4cdb-b781-f1ce0d72b103) failed because the personal environment install script runs `npm install`, but `package.json` was removed during the Laravel-to-vanilla-PHP migration. Only an orphaned empty `package-lock.json` remained.

`composer install` succeeded; `npm install` failed with `ENOENT` for `/workspace/package.json`.

## Solution

Add `.cursor/environment.json` so environment configuration is version-controlled with the codebase:

- **Install**: `composer install --no-interaction --no-progress` only (no npm)
- **Base image**: references the existing `.devcontainer/Dockerfile` so PHP and Composer are available on cold builds
- **Port**: exposes 8000 for the PHP dev server

This overrides the stale personal dashboard config per Cursor's configuration precedence (repo file > personal > team).

## Validation

- `composer install`, PHPUnit, and Pint pass without npm on this VM
- Draft environment build triggered to verify the full install path

## After merge

Once merged to `main`, trigger a new environment build from the default branch (promotable) and [enable builds](https://cursor.com/dashboard/cloud-agents/environments/e/a7ee4122-82d0-11f1-a7d1-d6b4613131ce) on the environment dashboard.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62a77c59-4989-409c-9d63-38007fb9e2ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62a77c59-4989-409c-9d63-38007fb9e2ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

